### PR TITLE
use DC CIVAC instead of DC IVAC as a better equivalent to CFLUSH on aarch64

### DIFF
--- a/src/common/fam.c
+++ b/src/common/fam.c
@@ -38,7 +38,7 @@ void fam_invalidate(const void *addr, size_t len) {
 #ifdef __x86_64__
         _mm_clflush((char *)uptr);
 #elif defined(__aarch64__)
-        asm volatile("dc\tivac, %0" : : "r"((char *)uptr) : "memory");
+        asm volatile("dc\tcivac, %0" : : "r"((char *)uptr) : "memory");
 #else
 #pragma error "No implementation for cache invalidation"
 #endif


### PR DESCRIPTION
use DC CIVAC instead of DC IVAC as a better equivalent to CFLUSH on x86. DC CIVAC should be a more safe option as it cleans (writes back to memory) and invalidates cache address instead of DC IVAC, which only invalidates.

[ref]
https://developer.arm.com/documentation/ddi0601/2024-09/AArch64-Instructions/DC-CIVAC--Data-or-unified-Cache-line-Clean-and-Invalidate-by-VA-to-PoC